### PR TITLE
Feature/waveform issue 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,30 @@
+name: Flutter CI
+
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `lib/` holds app code; features live under `lib/features/<feature>/` with `view`, `viewmodel`, `widget`, and `models` folders following MVVM. Core-wide utilities will eventually sit under `lib/core/`.
+- `test/` mirrors the feature layout (`test/features/voice_to_text/...`) for unit and widget coverage. Keep test helpers close to the code they exercise.
+- Platform scaffolding resides in the standard `android/`, `ios/`, `web/`, and desktop directories. Treat these as generated unless platform work is assigned.
+
+## Build, Test, and Development Commands
+
+- `flutter pub get` — sync dependencies declared in `pubspec.yaml`.
+- `flutter run` — launch the app using current configuration; defaults to `VoiceToTextScreen`.
+- `flutter test` — execute all unit and widget tests; use `flutter test test/features/...` for targeted suites.
+
+## Coding Style & Naming Conventions
+
+- Follow Dart style: 2-space indentation, `lowerCamelCase` for variables/methods, `UpperCamelCase` for types, and `snake_case.dart` filenames.
+- Widgets and view models live in dedicated files named after the class (`text_display.dart`, `voice_to_text_model.dart`).
+- Rely on Flutter’s formatter: `dart format .` or the IDE’s auto-format on save. Static analysis is enforced via `analysis_options.yaml`; resolve its warnings before committing.
+
+## Testing Guidelines
+
+- Write unit tests for view models and pure logic; use `flutter_test` for widget layout/animation checks (see `waveform_test.dart`).
+- Name tests descriptively using `group` + `testWidgets`/`test`; prefer arranging inputs/expectations inline for readability.
+- Ensure new features extend the mirrored directory structure in `test/` and run `flutter test` before pushing.
+
+## Commit & Pull Request Guidelines
+
+- Use commits conventions fix, tests, chore, feat, build, refactor
+- Commits in history use short, imperative messages (`Add waveform visualization`). Keep them scoped to a single concern and ensure formatting/lints pass (`flutter analyze` runs pre-commit via tooling).
+- Pull requests should:
+  1. Reference the corresponding GitHub issue in the description (`Fixes #2`).
+  2. Summarize functional changes plus any architectural notes (e.g., new providers).
+  3. Include screenshots or screen recordings for UI changes when feasible.
+  4. Confirm tests ran successfully (`flutter test`) and note any manual verification performed.
+
+## Architecture Overview
+
+- The app is converging on MVVM: views consume `VoiceToTextModelState`/future providers, while view models expose immutable state and notify listeners. New features should respect this separation and favor dependency injection for services.
+
+## Tools
+
+- ALWAYS use `gh` cli when interacting with github
+
+## Code style
+
+- Always follow the guidelines layout [here](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md)

--- a/lib/features/voice_to_text/view/voice_to_text_model.dart
+++ b/lib/features/voice_to_text/view/voice_to_text_model.dart
@@ -1,12 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 abstract class VoiceToTextModel extends Listenable {
   List<String> get transcript; // already tokenized words or segments
   int get activeWordIndex;
   bool get isCursorVisible;
+  List<double> get waveformData;
+  Stream<List<double>> get waveformStream;
 
   void setActiveWord(int index);
   void toggleCursorVisibility(bool visible);
+  void updateWaveform(List<double> amplitudes);
 
   // Other state already planned (timer, waveform, recording commands) lives here too.
 }
@@ -23,6 +28,9 @@ class VoiceToTextModelState extends ChangeNotifier implements VoiceToTextModel {
   final List<String> _transcript;
   int _activeWordIndex;
   bool _isCursorVisible;
+  List<double> _waveformData = const [];
+  final StreamController<List<double>> _waveformController =
+      StreamController<List<double>>.broadcast();
 
   @override
   List<String> get transcript => _transcript;
@@ -32,6 +40,12 @@ class VoiceToTextModelState extends ChangeNotifier implements VoiceToTextModel {
 
   @override
   bool get isCursorVisible => _isCursorVisible;
+
+  @override
+  List<double> get waveformData => _waveformData;
+
+  @override
+  Stream<List<double>> get waveformStream => _waveformController.stream;
 
   @override
   void setActiveWord(int index) {
@@ -46,5 +60,20 @@ class VoiceToTextModelState extends ChangeNotifier implements VoiceToTextModel {
     if (_isCursorVisible == visible) return;
     _isCursorVisible = visible;
     notifyListeners();
+  }
+
+  @override
+  void updateWaveform(List<double> amplitudes) {
+    _waveformData = List.unmodifiable(amplitudes);
+    notifyListeners();
+    if (!_waveformController.isClosed) {
+      _waveformController.add(_waveformData);
+    }
+  }
+
+  @override
+  void dispose() {
+    _waveformController.close();
+    super.dispose();
   }
 }

--- a/lib/features/voice_to_text/view/voice_to_text_screen.dart
+++ b/lib/features/voice_to_text/view/voice_to_text_screen.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../widget/text_display.dart';
+import '../widget/waveform.dart';
 import 'voice_to_text_model.dart';
 
 class VoiceToTextScreen extends StatelessWidget {
@@ -35,20 +39,83 @@ class VoiceToTextScreen extends StatelessWidget {
   }
 }
 
-class _VoiceToTextView extends StatelessWidget {
+class _VoiceToTextView extends StatefulWidget {
   const _VoiceToTextView();
 
   @override
+  State<_VoiceToTextView> createState() => _VoiceToTextViewState();
+}
+
+class _VoiceToTextViewState extends State<_VoiceToTextView> {
+  static const int _waveformSampleCount = 48;
+  static const Duration _waveformTick = Duration(milliseconds: 100);
+
+  final math.Random _random = math.Random();
+  Timer? _waveformTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final model = context.read<VoiceToTextModelState>();
+      _pushWaveformSample(model);
+      _waveformTimer = Timer.periodic(
+        _waveformTick,
+        (_) => _pushWaveformSample(model),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _waveformTimer?.cancel();
+    super.dispose();
+  }
+
+  void _pushWaveformSample(VoiceToTextModel model) {
+    final sample = List<double>.generate(_waveformSampleCount, (index) {
+      final variance = math.sin(index / 4) * 0.3 + 0.5;
+      final noise = (_random.nextDouble() - 0.5) * 0.2;
+      return (variance + noise).clamp(0.0, 1.0);
+    });
+    model.updateWaveform(sample);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final VoiceToTextModel model = context.watch<VoiceToTextModelState>();
+    final VoiceToTextModelState model = context.watch<VoiceToTextModelState>();
 
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 227, 227, 198),
       body: SafeArea(
-        child: TextDisplayWidget(
-          transcript: model.transcript,
-          activeWordIndex: model.activeWordIndex,
-          isCursorVisible: model.isCursorVisible,
+        child: Column(
+          children: [
+            Expanded(
+              flex: 2,
+              child: TextDisplayWidget(
+                transcript: model.transcript,
+                activeWordIndex: model.activeWordIndex,
+                isCursorVisible: model.isCursorVisible,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              flex: 3,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: WaveformStream(
+                  stream: model.waveformStream,
+                  initialAmplitudes: model.waveformData,
+                  height: 220,
+                  barColor: Colors.black87,
+                  barWidth: 3,
+                  spacing: 6,
+                  backgroundColor: Colors.transparent,
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
         ),
       ),
     );

--- a/lib/features/voice_to_text/widget/waveform.dart
+++ b/lib/features/voice_to_text/widget/waveform.dart
@@ -1,0 +1,217 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class WaveformWidget extends StatefulWidget {
+  const WaveformWidget({
+    super.key,
+    required this.amplitudes,
+    this.height = 220,
+    this.barColor = Colors.black,
+    this.barWidth = 3,
+    this.spacing = 6,
+    this.backgroundColor = Colors.transparent,
+    this.animationDuration = const Duration(milliseconds: 120),
+  });
+
+  final List<double> amplitudes;
+  final double height;
+  final Color barColor;
+  final double barWidth;
+  final double spacing;
+  final Color backgroundColor;
+  final Duration animationDuration;
+
+  @override
+  State<WaveformWidget> createState() => _WaveformWidgetState();
+}
+
+class _WaveformWidgetState extends State<WaveformWidget>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late List<double> _displayed;
+  late List<double> _start;
+  late List<double> _target;
+
+  @override
+  void initState() {
+    super.initState();
+    final normalized = WaveformPainter.normalize(widget.amplitudes);
+    _displayed = List<double>.from(normalized);
+    _start = List<double>.from(normalized);
+    _target = List<double>.from(normalized);
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.animationDuration,
+    )..addListener(_handleTick);
+  }
+
+  @override
+  void didUpdateWidget(covariant WaveformWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.duration = widget.animationDuration;
+    final normalized = WaveformPainter.normalize(widget.amplitudes);
+    _start = _resizeList(_displayed, normalized.length);
+    _target = _resizeList(normalized, normalized.length);
+    if (_target.isEmpty) {
+      setState(() {
+        _displayed = const [];
+      });
+      return;
+    }
+    _controller.forward(from: 0);
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_handleTick)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _handleTick() {
+    final t = Curves.easeOut.transform(_controller.value);
+    final result = <double>[];
+    final length = _target.length;
+    final current = _resizeList(_start, length);
+    for (var i = 0; i < length; i++) {
+      final interpolated = lerpDouble(current[i], _target[i], t) ?? _target[i];
+      result.add(interpolated);
+    }
+    setState(() {
+      _displayed = result;
+    });
+  }
+
+  List<double> _resizeList(List<double> source, int length) {
+    if (length == 0) {
+      return const [];
+    }
+    if (source.length == length) {
+      return List<double>.from(source);
+    }
+    final result = List<double>.filled(length, 0);
+    for (var i = 0; i < length; i++) {
+      result[i] = i < source.length ? source[i] : 0;
+    }
+    return result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: widget.height,
+      child: DecoratedBox(
+        decoration: BoxDecoration(color: widget.backgroundColor),
+        child: CustomPaint(
+          painter: WaveformPainter(
+            amplitudes: _displayed,
+            barColor: widget.barColor,
+            barWidth: widget.barWidth,
+            spacing: widget.spacing,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class WaveformPainter extends CustomPainter {
+  const WaveformPainter({
+    required this.amplitudes,
+    required this.barColor,
+    required this.barWidth,
+    required this.spacing,
+  });
+
+  final List<double> amplitudes;
+  final Color barColor;
+  final double barWidth;
+  final double spacing;
+
+  static List<double> normalize(List<double> values) {
+    return values
+        .map((value) {
+          final safeValue = value.isNaN ? 0.0 : value;
+          return safeValue.clamp(0.0, 1.0).toDouble();
+        })
+        .toList(growable: false);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (amplitudes.isEmpty) {
+      return;
+    }
+
+    final paint = Paint()
+      ..color = barColor
+      ..strokeWidth = barWidth
+      ..strokeCap = StrokeCap.round;
+
+    final totalWidth =
+        amplitudes.length * barWidth + (amplitudes.length - 1) * spacing;
+    final startX = (size.width - totalWidth) / 2;
+    final maxHeight = size.height;
+
+    for (var i = 0; i < amplitudes.length; i++) {
+      final normalized = amplitudes[i].clamp(0.0, 1.0).toDouble();
+      final barHeight = normalized * maxHeight;
+      final x = startX + i * (barWidth + spacing);
+      final top = (maxHeight - barHeight) / 2;
+      canvas.drawLine(Offset(x, top), Offset(x, top + barHeight), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant WaveformPainter oldDelegate) {
+    return oldDelegate.amplitudes != amplitudes ||
+        oldDelegate.barColor != barColor ||
+        oldDelegate.barWidth != barWidth ||
+        oldDelegate.spacing != spacing;
+  }
+}
+
+class WaveformStream extends StatelessWidget {
+  const WaveformStream({
+    super.key,
+    required this.stream,
+    required this.initialAmplitudes,
+    this.height = 220,
+    this.barColor = Colors.black,
+    this.barWidth = 3,
+    this.spacing = 6,
+    this.backgroundColor = Colors.transparent,
+    this.animationDuration = const Duration(milliseconds: 120),
+  });
+
+  final Stream<List<double>> stream;
+  final List<double> initialAmplitudes;
+  final double height;
+  final Color barColor;
+  final double barWidth;
+  final double spacing;
+  final Color backgroundColor;
+  final Duration animationDuration;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<double>>(
+      stream: stream,
+      initialData: initialAmplitudes,
+      builder: (context, snapshot) {
+        final amplitudes = snapshot.data ?? const <double>[];
+        return WaveformWidget(
+          amplitudes: amplitudes,
+          height: height,
+          barColor: barColor,
+          barWidth: barWidth,
+          spacing: spacing,
+          backgroundColor: backgroundColor,
+          animationDuration: animationDuration,
+        );
+      },
+    );
+  }
+}

--- a/test/features/voice_to_text/widget/waveform_test.dart
+++ b/test/features/voice_to_text/widget/waveform_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:iva_mobile/features/voice_to_text/widget/waveform.dart';
+
+void main() {
+  group('WaveformPainter', () {
+    test('normalizes values into 0-1 range and handles NaN', () {
+      final result = WaveformPainter.normalize([1.5, -0.1, double.nan]);
+      expect(result, [1.0, 0.0, 0.0]);
+    });
+  });
+
+  group('WaveformWidget', () {
+    testWidgets('renders CustomPaint with provided amplitudes', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: WaveformWidget(amplitudes: [0.2, 0.8])),
+        ),
+      );
+
+      final customPaintFinder = find.descendant(
+        of: find.byType(WaveformWidget),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint && widget.painter is WaveformPainter,
+        ),
+      );
+      expect(customPaintFinder, findsOneWidget);
+      final customPaint = tester.widget<CustomPaint>(customPaintFinder);
+      final painter = customPaint.painter as WaveformPainter;
+      expect(painter.amplitudes, [0.2, 0.8]);
+    });
+
+    testWidgets('animates to updated amplitudes', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: _WaveformHost())),
+      );
+
+      final state = tester.state<_WaveformHostState>(
+        find.byType(_WaveformHost),
+      );
+      state.update([0.9, 0.7]);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final customPaintFinder = find.descendant(
+        of: find.byType(WaveformWidget),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint && widget.painter is WaveformPainter,
+        ),
+      );
+      final painter =
+          tester.widget<CustomPaint>(customPaintFinder).painter
+              as WaveformPainter;
+      expect(painter.amplitudes, [0.9, 0.7]);
+    });
+  });
+}
+
+class _WaveformHost extends StatefulWidget {
+  const _WaveformHost();
+
+  @override
+  State<_WaveformHost> createState() => _WaveformHostState();
+}
+
+class _WaveformHostState extends State<_WaveformHost> {
+  List<double> _amplitudes = const [0.1, 0.3];
+
+  void update(List<double> amplitudes) {
+    setState(() {
+      _amplitudes = amplitudes;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WaveformWidget(
+      amplitudes: _amplitudes,
+      animationDuration: const Duration(milliseconds: 40),
+    );
+  }
+}


### PR DESCRIPTION
  # Summary

  - Build out the live waveform visualization (`lib/features/voice_to_text/widget/waveform.dart`) with smoothing
  animation, stream wrapper, and bar styling that matches the design guide.
  - Extend `VoiceToTextModelState` (`lib/features/voice_to_text/view/voice_to_text_model.dart`) to track waveform samples/stream and update the voice screen to render the widget with temporary mock data (`lib/features/voice_to_text/view/voice_to_text_screen.dart`).
  - Cover the new logic with unit/widget tests (`test/features/voice_to_text/view/voice_to_text_model_test.dart`, `test/
  features/voice_to_text/widget/waveform_test.dart`).
  - Document project conventions in `AGENTS.md` so contributors have a concise onboarding reference.
  - Add `.github/workflows/CI.yml` to run `flutter pub get` and `flutter test` on pushes and PRs via `subosito/flutter-
  action`.

 # Testing

  - flutter test