### PR TITLE
feat:Implemented the new control layout with animated mic ripple and …

### DIFF
--- a/lib/features/voice_to_text/widget/control_buttons.dart
+++ b/lib/features/voice_to_text/widget/control_buttons.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+
+import '../view/voice_to_text_model.dart';
+
+class ControlButtonsRow extends StatelessWidget {
+  const ControlButtonsRow({
+    super.key,
+    required this.state,
+    required this.onMicTap,
+    required this.onPause,
+    required this.onResume,
+    required this.onDiscard,
+  });
+
+  final RecordingState state;
+  final VoidCallback onMicTap;
+  final VoidCallback onPause;
+  final VoidCallback onResume;
+  final VoidCallback onDiscard;
+
+  bool get _showSecondary =>
+      state == RecordingState.recording || state == RecordingState.paused;
+
+  @override
+  Widget build(BuildContext context) {
+    final leftIcon = state == RecordingState.paused
+        ? Icons.play_arrow
+        : Icons.pause;
+    final leftLabel = state == RecordingState.paused
+        ? 'Resume recording'
+        : 'Pause recording';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 32),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: _showSecondary
+                ? _SecondaryCircularButton(
+                    key: const ValueKey('pause_button'),
+                    icon: leftIcon,
+                    tooltip: leftLabel,
+                    onPressed: state == RecordingState.paused
+                        ? onResume
+                        : onPause,
+                  )
+                : const SizedBox(width: 64, height: 64),
+          ),
+          const SizedBox(width: 24),
+          _MicButton(
+            isRecording: state == RecordingState.recording,
+            onPressed: onMicTap,
+            state: state,
+          ),
+          const SizedBox(width: 24),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: _showSecondary
+                ? _SecondaryCircularButton(
+                    key: const ValueKey('discard_button'),
+                    icon: Icons.delete_outline,
+                    tooltip: 'Discard recording',
+                    onPressed: onDiscard,
+                  )
+                : const SizedBox(width: 64, height: 64),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SecondaryCircularButton extends StatelessWidget {
+  const _SecondaryCircularButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: SizedBox(
+        width: 64,
+        height: 64,
+        child: Material(
+          color: Colors.transparent,
+          shape: const CircleBorder(),
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onPressed,
+            child: Ink(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.black.withValues(alpha: 0.2)),
+              ),
+              child: Center(child: Icon(icon, color: Colors.black87, size: 28)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MicButton extends StatefulWidget {
+  const _MicButton({
+    required this.isRecording,
+    required this.onPressed,
+    required this.state,
+  });
+
+  final bool isRecording;
+  final RecordingState state;
+  final VoidCallback onPressed;
+
+  @override
+  State<_MicButton> createState() => _MicButtonState();
+}
+
+class _MicButtonState extends State<_MicButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    );
+    if (widget.isRecording) {
+      _controller.repeat();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _MicButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isRecording && !_controller.isAnimating) {
+      _controller.repeat();
+    } else if (!widget.isRecording && _controller.isAnimating) {
+      _controller
+        ..stop()
+        ..reset();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = switch (widget.state) {
+      RecordingState.recording => 'Stop recording',
+      RecordingState.paused => 'Stop recording',
+      RecordingState.stopped => 'Start new recording',
+      RecordingState.idle => 'Start recording',
+    };
+
+    final button = Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: widget.onPressed,
+        customBorder: const CircleBorder(),
+        child: Ink(
+          width: 88,
+          height: 88,
+          decoration: const BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              colors: [
+                Color.fromARGB(255, 0, 0, 0),
+                Color.fromARGB(255, 0, 0, 0),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: const Icon(Icons.mic, size: 36, color: Colors.white),
+        ),
+      ),
+    );
+
+    return Semantics(
+      label: tooltip,
+      button: true,
+      child: SizedBox(
+        width: 120,
+        height: 120,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            if (widget.isRecording)
+              ...List.generate(3, (index) {
+                return AnimatedBuilder(
+                  animation: _controller,
+                  builder: (context, child) {
+                    final progress = (_controller.value + index / 3) % 1;
+                    final scale = 1 + (progress * 0.6);
+                    final opacity = (1 - progress).clamp(0.0, 1.0);
+                    return Transform.scale(
+                      scale: scale,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: const Color.fromARGB(
+                            255,
+                            87,
+                            88,
+                            88,
+                          ).withValues(alpha: 0.1 * opacity),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              }),
+            Tooltip(message: tooltip, child: button),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/voice_to_text/widget/waveform.dart
+++ b/lib/features/voice_to_text/widget/waveform.dart
@@ -1,4 +1,3 @@
-import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -151,14 +150,14 @@ class WaveformPainter extends CustomPainter {
       return;
     }
 
+    final totalWidth =
+        amplitudes.length * barWidth + (amplitudes.length - 1) * spacing;
+    final startX = (size.width - totalWidth) / 2;
+
     final paint = Paint()
       ..color = barColor
       ..strokeWidth = barWidth
       ..strokeCap = StrokeCap.round;
-
-    final totalWidth =
-        amplitudes.length * barWidth + (amplitudes.length - 1) * spacing;
-    final startX = math.max((size.width - totalWidth) / 2, 0.0);
     final maxHeight = size.height;
 
     for (var i = 0; i < amplitudes.length; i++) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -142,6 +142,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -179,6 +184,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   json_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.5+1
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/test/features/voice_to_text/view/voice_to_text_model_test.dart
+++ b/test/features/voice_to_text/view/voice_to_text_model_test.dart
@@ -132,5 +132,47 @@ void main() {
         model.dispose();
       });
     });
+
+    test('recording state transitions control timer lifecycle', () {
+      fakeAsync((async) {
+        final model = VoiceToTextModelState(initialTranscript: transcript);
+
+        expect(model.recordingState, RecordingState.idle);
+
+        model.startRecording();
+        expect(model.recordingState, RecordingState.recording);
+        async.elapse(const Duration(seconds: 2));
+        expect(model.elapsedDuration, const Duration(seconds: 2));
+
+        model.pauseRecording();
+        expect(model.recordingState, RecordingState.paused);
+        async.elapse(const Duration(seconds: 1));
+        expect(model.elapsedDuration, const Duration(seconds: 2));
+
+        model.resumeRecording();
+        expect(model.recordingState, RecordingState.recording);
+        async.elapse(const Duration(seconds: 1));
+        expect(model.elapsedDuration, const Duration(seconds: 3));
+
+        model.stopRecording();
+        expect(model.recordingState, RecordingState.stopped);
+        expect(model.elapsedDuration, Duration.zero);
+
+        model.restartRecording();
+        expect(model.recordingState, RecordingState.recording);
+        expect(model.elapsedDuration, Duration.zero);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(model.elapsedDuration, const Duration(seconds: 1));
+
+        model.updateWaveform([0.2, 0.4]);
+        model.discardRecording();
+        expect(model.recordingState, RecordingState.idle);
+        expect(model.elapsedDuration, Duration.zero);
+        expect(model.waveformData, isEmpty);
+
+        model.dispose();
+      });
+    });
   });
 }

--- a/test/features/voice_to_text/widget/control_buttons_test.dart
+++ b/test/features/voice_to_text/widget/control_buttons_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:iva_mobile/features/voice_to_text/view/voice_to_text_model.dart';
+import 'package:iva_mobile/features/voice_to_text/widget/control_buttons.dart';
+
+void main() {
+  testWidgets('shows only microphone button when idle', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [Locale('en', 'US')],
+        home: Scaffold(
+          body: ControlButtonsRow(
+            state: RecordingState.idle,
+            onMicTap: _noop,
+            onPause: _noop,
+            onResume: _noop,
+            onDiscard: _noop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.mic), findsOneWidget);
+    expect(find.byIcon(Icons.pause), findsNothing);
+    expect(find.byIcon(Icons.delete_outline), findsNothing);
+  });
+
+  testWidgets('shows pause and discard while recording', (tester) async {
+    RecordingState currentState = RecordingState.recording;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [Locale('en', 'US')],
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return ControlButtonsRow(
+                state: currentState,
+                onMicTap: () {},
+                onPause: () => setState(() {
+                  currentState = RecordingState.paused;
+                }),
+                onResume: () => setState(() {
+                  currentState = RecordingState.recording;
+                }),
+                onDiscard: () => setState(() {
+                  currentState = RecordingState.idle;
+                }),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.pause), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.pause));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    expect(currentState, RecordingState.idle);
+  });
+}
+
+void _noop() {}


### PR DESCRIPTION
# Description

## Mic Button & Animation
- Rebuilt the control row to center a gradient `Icons.mic` button that launches/stops recording.
- When `RecordingState.recording`, a 3-layer pulse animation loops via `AnimationController` to mimic the reference ripple; paused/stopped states halt the animation so the mic stays calm.

## Contextual Actions
- Added side buttons that fade in only while a session is active (recording or paused): left toggles pause/ resume, right discards via a trash icon. Idle/stopped states hide both, keeping the mic centered.
- Updated the screen wiring to provide explicit callbacks (`_handleMicTap`, pause/resume/discard) and revised the `ViewModel` to manage a `RecordingState` enum plus `discardRecording()`.

## State Logic Enhancements
- `ViewModel` now tracks `recordingState`, resets timers on stop/discard, and clears waveform data when discarding
  for a clean restart.

## Tests & Dependencies
- Expanded unit tests to cover the new state transitions and discard behavior; added widget tests verifying button visibility/toggling with localization support.
- Added flutter_localizations for tooltip/localization needs referenced by the controls
- flutter test passes.